### PR TITLE
Fix/add learning rate as arg

### DIFF
--- a/.github/workflows/create_asset.yml
+++ b/.github/workflows/create_asset.yml
@@ -125,7 +125,8 @@ jobs:
             --boundary data/boundary_data.parquet \
             --model test_model.joblib \
             --epochs 1000 \
-            --every 100
+            --every 100 \
+            --learning-rate 5e-2
     
       - name: Inference
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -135,7 +135,8 @@ jobs:
             --boundary data/boundary_data.parquet \
             --model test_model.joblib \
             --epochs 1000 \
-            --every 100
+            --every 100 \
+            --learning-rate 1e-3
     
       - name: Inference
         run: |

--- a/cli/commands/train.py
+++ b/cli/commands/train.py
@@ -6,6 +6,7 @@ def cmd_train(args):
     domain = cli.utils.datatools.parquet_to_tensor(args.domain)
     boundary = cli.utils.datatools.parquet_to_tensor(args.boundary)
     model = joblib.load(args.model)
+    lr = args.lr
     # loss
     epochs = args.epochs
     every = args.every
@@ -15,7 +16,8 @@ def cmd_train(args):
         boundary=boundary,
         model=model,
         epochs=epochs,
-        every=every
+        every=every,
+        lr=lr
         )
     print(results)
     joblib.dump(trained_model, args.model)

--- a/cli/core/train.py
+++ b/cli/core/train.py
@@ -30,7 +30,7 @@ def train_pinn(
         lr: float = 1e-3,
         every: int = 200
 ) -> Dict[str, Any]:
-    optimizer: tf.keras.optimizers = tf.keras.optimizers.Adam(learning_rate=lr),
+    optimizer: tf.keras.optimizers = tf.keras.optimizers.Adam(learning_rate=lr)
     loss_values = np.array([])
     u = cli.utils.modeltools.model_wrapper(model)
     #

--- a/cli/core/train.py
+++ b/cli/core/train.py
@@ -27,9 +27,10 @@ def train_pinn(
         loss_func: Callable[[tf.Tensor, tf.Tensor], tf.Tensor] = mse,
         # pde: Callable[[tf.Tensor, tf.Tensor | None, tf.Tensor | None, tf.Tensor | None], tf.Tensor],
         epochs: int = 200, 
-        optimizer: tf.keras.optimizers = tf.keras.optimizers.Adam(learning_rate=5e-3),
+        lr: float = 1e-3,
         every: int = 200
 ) -> Dict[str, Any]:
+    optimizer: tf.keras.optimizers = tf.keras.optimizers.Adam(learning_rate=lr),
     loss_values = np.array([])
     u = cli.utils.modeltools.model_wrapper(model)
     #

--- a/cli/heat.py
+++ b/cli/heat.py
@@ -77,6 +77,14 @@ def make_parser() -> argparse.ArgumentParser:
         type=str,
         help="Path of model file"
     )
+    p_train.add_argument(
+        "-l",
+        "--lr",
+        "--learning-rate",
+        type=float, 
+        default=1e-3,
+        help="Learning rate for the optimizer"
+    )
     # p_train.add_argument("--pde", type=int, default=1)
     # p_train.add_argument("--loss", type=int, default=20)
     p_train.add_argument(


### PR DESCRIPTION
# Summary

Learning rate added as a CLI arg in `train` subcommand. `-l`, `--lr` or `--learning-rate`, as a float, which accepts scientific notation (e.g. `1e-3`)